### PR TITLE
Update action.yml to use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,5 +55,5 @@ inputs:
       not set.
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Fix this warning when using this action:

>The following actions use a deprecated Node.js version and will be forced to run on node20: canonical/create-pull-request@5b97f11bd11d44ed8c4ad49f60d6f529374b1e87. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default

